### PR TITLE
fix: optional parameter set as required

### DIFF
--- a/supersphincs.d.ts
+++ b/supersphincs.d.ts
@@ -102,7 +102,7 @@ declare module 'supersphincs' {
 			},
 			additionalData?: Uint8Array|string,
 			knownGoodHash?: Uint8Array|string,
-			includeHash: true
+			includeHash?: true
 		) : Promise<{
 			hash: Uint8Array;
 			message: Uint8Array;
@@ -126,7 +126,7 @@ declare module 'supersphincs' {
 			},
 			additionalData?: Uint8Array|string,
 			knownGoodHash?: Uint8Array|string,
-			includeHash: true
+			includeHash?: true
 		) : Promise<{
 			hash: string;
 			message: Uint8Array;
@@ -182,7 +182,7 @@ declare module 'supersphincs' {
 			},
 			additionalData?: Uint8Array|string,
 			knownGoodHash?: Uint8Array|string,
-			includeHash: true
+			includeHash?: true
 		) : Promise<{
 			hash: Uint8Array;
 			valid: boolean;


### PR DESCRIPTION
Hello!

I imported this library in a project and TypeScript raised an exception stating that required parameters can't be placed after optional parameters in a function. I noticed that the parameter 'includeHash' has a default value, so marking it as optional should solve the issue.